### PR TITLE
Change default planning group

### DIFF
--- a/src/stretch_re1_pro_config/config/config.yaml
+++ b/src/stretch_re1_pro_config/config/config.yaml
@@ -98,7 +98,7 @@ optional_feature_params:
 # [Required]
 moveit_params:
   # Used by the Waypoint Manager to save joint states from this joint group.
-  joint_group_name: "stretch_arm"
+  joint_group_name: "mobile_base_arm"
 
   ompl_planning:
     package: "stretch_re1_pro_config"

--- a/src/stretch_re1_pro_config/config/moveit/stretch_servo.yaml
+++ b/src/stretch_re1_pro_config/config/moveit/stretch_servo.yaml
@@ -36,8 +36,8 @@ smoothing_filter_plugin_name: "online_signal_smoothing::AccelerationLimitedPlugi
 acceleration_filter_update_period: 0.01 # [seconds] Must match the publish_period parameter
 
 ## MoveIt properties
-move_group_name: stretch_arm  # Often 'manipulator' or 'arm'
-acceleration_filter_planning_group_name: stretch_arm  # Often 'manipulator' or 'arm'
+move_group_name: mobile_base_arm  # Often 'manipulator' or 'arm'
+acceleration_filter_planning_group_name: mobile_base_arm  # Often 'manipulator' or 'arm'
 is_primary_planning_scene_monitor: false  # The MoveGroup node maintains the planning scene, so Servo needs to get its world info from there.
 
 ## Stopping behaviour
@@ -46,7 +46,7 @@ incoming_command_timeout: 0.1  # Stop servoing if X seconds elapse without a new
 ## Configure handling of singularities and joint limits
 lower_singularity_threshold: 30.0  # Start decelerating when the condition number hits this (close to singularity)
 hard_stop_singularity_threshold: 50.0 # Stop when the condition number hits this
-joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1] # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
+joint_limit_margins: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1] # added as a buffer to joint limits [radians]. If moving quickly, make this larger.
 
 ## Topic names
 cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian twist commands


### PR DESCRIPTION
Resolves https://github.com/PickNikRobotics/moveit_studio/issues/7533
The default planning group is the `move_group` parameter in the servo YAML